### PR TITLE
Allow use of impala adapter when gssapi doesn't support the OS

### DIFF
--- a/lib/impala.rb
+++ b/lib/impala.rb
@@ -10,7 +10,12 @@ require 'impala/version'
 require 'thrift'
 require 'time'
 require 'impala/protocol'
+begin
 require 'impala/sasl_transport'
+rescue LoadError
+  # gssapi not supported by operating system, continue as impala adapter
+  # can be used in buffered (non-SASL) mode.
+end
 require 'impala/cursor'
 require 'impala/connection'
 require 'impala/thrift_patch'


### PR DESCRIPTION
gssapi supports only the most popular operating systems.  As you
only need the gssapi support if you are going to be using SASL,
it may be better to only load the sasl_transport code in that case.
However, this at least allows use of impala if gssapi is not
supported.