### PR TITLE
Attempt to address unrecognized disconnect error in jdbc/hive2 adapter

### DIFF
--- a/lib/sequel/adapters/jdbc/hive2.rb
+++ b/lib/sequel/adapters/jdbc/hive2.rb
@@ -15,6 +15,11 @@ module Sequel
     module Hive2
       module DatabaseMethods
         include Sequel::Impala::DatabaseMethods
+
+        # Recognize wrapped java.net.SocketExceptions as disconnect errors
+        def disconnect_error?(exception, opts)
+          super || exception.message =~ /\AJava::JavaSql::SQLException: org\.apache\.thrift\.transport\.TTransportException: java\.net\.SocketException/
+        end
       end
 
       class Dataset < JDBC::Dataset


### PR DESCRIPTION
In general most socket exceptions are going to be disconnect errors.
I'm not sure if all TTransportExceptions are going to be disconnect
errors, but the regexp can be generalized if this doesn't catch all
necessary cases.