### PR TITLE
Fix some Sequel deprecation warnings

### DIFF
--- a/lib/sequel/adapters/impala.rb
+++ b/lib/sequel/adapters/impala.rb
@@ -72,6 +72,10 @@ module Sequel
 
       private
 
+      def dataset_class_default
+        Dataset
+      end
+
       def record_profile(cursor, opts)
         if cursor && profile_name = opts[:profile_name]
           profile = cursor.runtime_profile
@@ -134,8 +138,6 @@ module Sequel
 
     class Dataset < Sequel::Dataset
       include DatasetMethods
-
-      Database::DatasetClass = self
 
       APOS = "'".freeze
       STRING_ESCAPES = {

--- a/lib/sequel/adapters/rbhive.rb
+++ b/lib/sequel/adapters/rbhive.rb
@@ -95,6 +95,10 @@ module Sequel
         :execute
       end
 
+      def dataset_class_default
+        Dataset
+      end
+
       # Impala raises IOError if it detects a problem on the connection, and
       # in most cases that results in an unusable connection, so treat it as a
       # disconnect error so Sequel will reconnect.
@@ -129,8 +133,6 @@ module Sequel
 
     class Dataset < Sequel::Dataset
       include Impala::DatasetMethods
-
-      Database::DatasetClass = self
 
       APOS = "'".freeze
       STRING_ESCAPES = {

--- a/lib/sequel/adapters/shared/impala.rb
+++ b/lib/sequel/adapters/shared/impala.rb
@@ -555,7 +555,7 @@ module Sequel
             select_append(Sequel.expr(1).as(EXCEPT_SOURCE_COLUMN)).
             union(rhs, all: true).
             select_group(*cols).
-            having{{count{}.* => 1, min(EXCEPT_SOURCE_COLUMN) => 1}}
+            having{{count.function.* => 1, min(EXCEPT_SOURCE_COLUMN) => 1}}
         end
 
         ds.from_self(opts)

--- a/lib/sequel/adapters/shared/impala.rb
+++ b/lib/sequel/adapters/shared/impala.rb
@@ -408,9 +408,9 @@ module Sequel
       BOOL_TRUE = 'true'.freeze
       BOOL_FALSE = 'false'.freeze
       CONSTANT_LITERAL_MAP = {:CURRENT_TIMESTAMP=>'now()'.freeze}.freeze
-      PAREN_OPEN = Dataset::PAREN_OPEN
-      PAREN_CLOSE = Dataset::PAREN_CLOSE
-      SPACE = Dataset::SPACE
+      PAREN_OPEN = '('.freeze
+      PAREN_CLOSE = ')'.freeze
+      SPACE = ' '.freeze
       NOT = 'NOT '.freeze
       REGEXP = ' REGEXP '.freeze
       EXCEPT_SOURCE_COLUMN = :__source__


### PR DESCRIPTION
Recent versions of Sequel have added deprecation warnings for
behavior that will be removed or changed in Sequel 5.  This fixes
the deprecation warnings when loading the adapter, as well as
one of the ones I ran into when testing.  I didn't run the full test
suite, so there could be other deprecation warnings these commits
do not cover.