### PR TITLE
Add jdbc/impala and sequel/adapters/jdbc/impala

### DIFF
--- a/lib/jdbc/impala.rb
+++ b/lib/jdbc/impala.rb
@@ -1,0 +1,50 @@
+warn 'jdbc-impala is only for use with JRuby' if (JRUBY_VERSION.nil? rescue true)
+
+module Jdbc
+  module Impala
+    DRIVER_VERSION = '2.5.41.1061'
+    VERSION = DRIVER_VERSION
+    JAR_ROOT = ENV['IMPALA_JDBC_JARS']
+    unless JAR_ROOT && File.directory?(JAR_ROOT)
+      warn "must specify IMPALA_JDBC_JARS environment variable for directory containing necessary jar files for Impala JDBC 4.1 driver version #{VERSION}"
+      raise LoadError, "cannot load such file -- jdbc/impala"
+    end
+
+    def self.driver_jar
+      %W(
+        ImpalaJDBC41.jar
+        TCLIServiceClient.jar
+        commons-codec-1.3.jar
+        commons-logging-1.1.1.jar
+        hive_metastore.jar
+        hive_service.jar
+        httpclient-4.1.3.jar
+        httpcore-4.1.3.jar
+        libfb303-0.9.0.jar
+        libthrift-0.9.0.jar
+        log4j-1.2.14.jar
+        ql.jar
+        slf4j-api-1.5.11.jar
+        slf4j-log4j12-1.5.11.jar
+        zookeeper-3.4.6.jar
+      ).map{|f| File.join(JAR_ROOT, f)}
+    end
+
+    def self.load_driver(method = :load)
+      driver_jar.each do |jar|
+        send method, jar
+      end
+    end
+
+    def self.driver_name
+      'com.cloudera.impala.jdbc41.Driver'
+    end
+
+    if defined?(JRUBY_VERSION) && # enable backwards-compat behavior
+      (Java::JavaLang::Boolean.get_boolean('jdbc.driver.autoload'))
+      warn "autoloading jdbc driver on require 'jdbc/impala'" if $VERBOSE
+      load_driver :require
+    end
+  end
+end
+

--- a/lib/sequel/adapters/jdbc/impala.rb
+++ b/lib/sequel/adapters/jdbc/impala.rb
@@ -1,0 +1,33 @@
+require 'sequel/adapters/shared/impala'
+
+Sequel::JDBC.load_driver('com.cloudera.impala.jdbc41.Driver', :Impala)
+
+module Sequel
+  module JDBC
+    Sequel.synchronize do
+      DATABASE_SETUP[:impala] = proc do |db|
+        db.extend(Sequel::JDBC::Impala::DatabaseMethods)
+        db.extend_datasets(Sequel::Impala::DatasetMethods)
+        com.cloudera.impala.jdbc41.Driver
+      end
+    end
+
+    module Impala
+      module DatabaseMethods
+        include Sequel::Impala::DatabaseMethods
+
+        # Recognize wrapped and unwrapped java.net.SocketExceptions as disconnect errors
+        def disconnect_error?(exception, opts)
+          super || exception.message =~ /\A(Java::JavaSql::SQLException: )?org\.apache\.thrift\.transport\.TTransportException: java\.net\.SocketException/
+        end
+
+        def disconnect_connection(c)
+          super
+        rescue java.sql.SQLException
+          nil
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Since Cloudera does not allow the redistribution of the Impala
JDBC jar files, you need to download the Impala JDBC driver
separately, unzip the Impala JDBC 4.1 driver package for the
matching version (2.5.41.1061), and specify the directory
containing the jar files via the IMPALA_JDBC_JARS environment
variable.