### PR TITLE
Work with Sequel 5

### DIFF
--- a/lib/sequel/adapters/impala.rb
+++ b/lib/sequel/adapters/impala.rb
@@ -44,7 +44,7 @@ module Sequel
         synchronize(opts[:server]) do |c|
           begin
             cursor = record_query_id(opts) do
-              log_yield(sql) do
+              log_connection_yield(sql, c) do
                 c.execute(sql){}
               end
             end

--- a/lib/sequel/adapters/rbhive.rb
+++ b/lib/sequel/adapters/rbhive.rb
@@ -75,7 +75,7 @@ module Sequel
         synchronize(opts[:server]) do |c|
           begin
             puts sql
-            r = log_yield(sql){c.execute(sql)}
+            r = log_connection_yield(sql, c){c.execute(sql)}
             yield(c, r) if block_given?
             nil
           rescue *RbhiveExceptions => e


### PR DESCRIPTION
This also should work with later versions of Sequel 4, but I'm not
sure how far back (possibly 4.42, possibly not).

There are also a couple of changes to allow working with frozen
literal strings.  While sequel-impala doesn't use them currently,
the adapters that ship with Sequel do.

This hasn't been extensively tested, and other changes may be
required for full compatibility.