### PR TITLE
Automatically run USE for new connections if :database is specified

### DIFF
--- a/lib/sequel/adapters/impala.rb
+++ b/lib/sequel/adapters/impala.rb
@@ -28,7 +28,7 @@ module Sequel
       # are respected, and they default to 'localhost' and 21000, respectively.
       def connect(server)
         opts = server_opts(server)
-        ::Impala.connect(opts[:host]||'localhost', (opts[:port]||21000).to_i, opts)
+        force_database(::Impala.connect(opts[:host]||'localhost', (opts[:port]||21000).to_i, opts))
       end
 
       def database_error_classes

--- a/lib/sequel/adapters/impala.rb
+++ b/lib/sequel/adapters/impala.rb
@@ -28,7 +28,7 @@ module Sequel
       # are respected, and they default to 'localhost' and 21000, respectively.
       def connect(server)
         opts = server_opts(server)
-        force_database(::Impala.connect(opts[:host]||'localhost', (opts[:port]||21000).to_i, opts))
+        force_database(::Impala.connect(opts[:host]||'localhost', (opts[:port]||21000).to_i, opts), opts[:database])
       end
 
       def database_error_classes

--- a/lib/sequel/adapters/rbhive.rb
+++ b/lib/sequel/adapters/rbhive.rb
@@ -58,7 +58,7 @@ module Sequel
         conn = RBHive::TCLIConnection.new(opts[:host]||'localhost', opts[:port]||21050, opts, opts[:hive_logger] || NullLogger)
         conn.open
         conn.open_session
-        force_database(conn)
+        force_database(conn, opts[:database])
       end
 
       def database_error_classes

--- a/lib/sequel/adapters/rbhive.rb
+++ b/lib/sequel/adapters/rbhive.rb
@@ -58,7 +58,7 @@ module Sequel
         conn = RBHive::TCLIConnection.new(opts[:host]||'localhost', opts[:port]||21050, opts, opts[:hive_logger] || NullLogger)
         conn.open
         conn.open_session
-        conn
+        force_database(conn)
       end
 
       def database_error_classes

--- a/lib/sequel/adapters/shared/impala.rb
+++ b/lib/sequel/adapters/shared/impala.rb
@@ -26,10 +26,6 @@ module Sequel
         run(compute_stats_sql(table_name))
       end
 
-      def connect(opts)
-        force_database(super)
-      end
-
       # Create a database/schema in Imapala.
       #
       # Options:
@@ -394,8 +390,8 @@ module Sequel
         opts.map { |k, v| "SET #{k}=#{v}" }
       end
 
-      def force_database(conn)
-        if database = @opts[:database]
+      def force_database(conn, database)
+        if database
           log_connection_execute(conn, "USE #{database}")
         end
         conn

--- a/lib/sequel/adapters/shared/impala.rb
+++ b/lib/sequel/adapters/shared/impala.rb
@@ -26,6 +26,10 @@ module Sequel
         run(compute_stats_sql(table_name))
       end
 
+      def connect(opts)
+        force_database(super)
+      end
+
       # Create a database/schema in Imapala.
       #
       # Options:
@@ -388,6 +392,13 @@ module Sequel
 
       def set_sql(opts)
         opts.map { |k, v| "SET #{k}=#{v}" }
+      end
+
+      def force_database(conn)
+        if database = @opts[:database]
+          log_connection_execute(conn, "USE #{database}")
+        end
+        conn
       end
     end
 

--- a/lib/sequel/adapters/shared/impala.rb
+++ b/lib/sequel/adapters/shared/impala.rb
@@ -316,7 +316,7 @@ module Sequel
       # SHOW TABLE STATS will raise an error if given a view and not a table,
       # so use that to differentiate tables from views.
       def is_valid_table?(t, opts=OPTS)
-        t = [opts[:schema], t].map(&:to_s).join('__').to_sym if opts[:schema]
+        t = Sequel.qualify(opts[:schema], t) if opts[:schema]
         rows = describe(t, :formatted=>true)
         if row = rows.find{|r| r[:name].to_s.strip == 'Table Type:'}
           row[:type].to_s.strip !~ /VIEW/


### PR DESCRIPTION
The ruby impala driver doesn't take a database argument, so it
always connects to the default database.  This issues a USE
statement so the default database is set for each new connection,
so it works similar to other databases.

This probably won't help JDBC connections unless the :database
option is specified manually, since the JDBC connection strings
are not parsed by Sequel, but hopefully the JDBC drivers handle
the database part of the URL correctly.