### PR TITLE
Explictly disconnect jdbc/impala Databases at exit

### DIFF
--- a/lib/sequel/adapters/jdbc/impala.rb
+++ b/lib/sequel/adapters/jdbc/impala.rb
@@ -8,6 +8,11 @@ module Sequel
       DATABASE_SETUP[:impala] = proc do |db|
         db.extend(Sequel::JDBC::Impala::DatabaseMethods)
         db.extend_datasets(Sequel::Impala::DatasetMethods)
+
+        # Explicitly disconnect at exit, which can fix issues where
+        # existing without disconnecting causes problems.
+        at_exit{db.disconnect}
+
         com.cloudera.impala.jdbc41.Driver
       end
     end


### PR DESCRIPTION
This should hopefully fix issues where the implicit cleanup during
exit takes much longer than it should.