### PR TITLE
Support :semi_join_first option when inner joining

### DIFF
--- a/lib/sequel/adapters/shared/impala.rb
+++ b/lib/sequel/adapters/shared/impala.rb
@@ -583,6 +583,12 @@ module Sequel
       # :shuffle, or an array containing both. Use of a join hint automatically
       # forces the use of the STRAIGHT_JOIN in the query.
       def join_table(type, table, expr=nil, options=OPTS, &block)
+        if type == :inner && options[:semi_join_first]
+          ds = left_semi_join(table, expr, options, &block)
+          alias_name = alias_symbol(opts[:from].first)
+          return ds.from_self(:alias=>alias_name).join(table, expr, options.merge(semi_join_first: nil))
+        end
+
         ds = super(type, db.implicit_qualify(table), expr, options, &block)
 
         if join_hints = options[:hints]

--- a/lib/sequel/adapters/shared/impala.rb
+++ b/lib/sequel/adapters/shared/impala.rb
@@ -563,6 +563,23 @@ module Sequel
         sql
       end
 
+      # Before running the query, check if there are any semi_join_first temporary
+      # tables to create, and if so, create them before the query and remove them
+      # after the query.
+      def each
+        tables = {}
+        populate_semi_join_first_tables(self, tables)
+        tables.each do |temp_table, ds|
+          db.create_table(temp_table, :as=>ds)
+        end
+
+        super 
+      ensure
+        if tables
+          db.drop_table(*tables.map(&:first))
+        end
+      end
+
       # Implicitly qualify tables if using the :search_path database option.
       def from(*)
         ds = super
@@ -582,11 +599,28 @@ module Sequel
       # Handle the :hints option to specify join hints, such as :broadcast,
       # :shuffle, or an array containing both. Use of a join hint automatically
       # forces the use of the STRAIGHT_JOIN in the query.
+      #
+      # Also support the :semi_join_first option if the type is :inner.  In that
+      # case, if :semi_join_first is true, first perform a left semi join instead of
+      # an inner join in a subquery, and then inner join that subquery to the table.
+      # If :semi_join_first represents a table name, inner join to the table name,
+      # and when executing the query, first create the table name using a left
+      # semi join, and after executing the query, drop the table name.
       def join_table(type, table, expr=nil, options=OPTS, &block)
-        if type == :inner && options[:semi_join_first]
+        if type == :inner && (temp_table = options[:semi_join_first])
           ds = left_semi_join(table, expr, options, &block)
           alias_name = alias_symbol(opts[:from].first)
-          return ds.from_self(:alias=>alias_name).join(table, expr, options.merge(semi_join_first: nil))
+
+          ds = case temp_table
+          when Symbol, String, SQL::Identifier, SQL::QualifiedIdentifier
+            db.from(Sequel.as(temp_table, alias_name)).clone(:semi_join_first_tables=>(opts[:semi_join_first_tables] || []) + [[temp_table, ds]])
+          when true
+            ds.from_self(:alias=>alias_name)
+          else
+            raise Sequel::Error, "invalid :semi_join_first option value when joining: #{temp_table.inspect}"
+          end
+
+          return ds.join(table, expr, options.merge(semi_join_first: nil))
         end
 
         ds = super(type, db.implicit_qualify(table), expr, options, &block)
@@ -885,11 +919,30 @@ module Sequel
         super
       end
 
-
       # Support VALUES clause instead of the SELECT clause to return rows.
       def select_values_sql(sql)
         sql << SELECT_VALUES
         expression_list_append(sql, opts[:values])
+      end
+
+      # Look in the current query and any subqueries in the FROM or JOIN
+      # clauses (including nested subqueries) to find all semi_join_first
+      # tables to create.
+      def populate_semi_join_first_tables(object, tables)
+        case object
+        when Sequel::Dataset
+          descend_into = (object.opts[:from] || []) + (object.opts[:join] || [])
+          descend_into.each{|f| populate_semi_join_first_tables(f, tables)}
+          if sjf = object.opts[:semi_join_first_tables]
+            sjf.each do |temp_table, ds|
+              tables[temp_table] ||= ds
+            end
+          end
+        when Sequel::SQL::AliasedExpression
+          populate_semi_join_first_tables(object.expression, tables)
+        when Sequel::SQL::JoinClause
+          populate_semi_join_first_tables(object.table_expr, tables)
+        end
       end
     end
   end

--- a/spec/impala_test.rb
+++ b/spec/impala_test.rb
@@ -82,6 +82,10 @@ describe "Impala dataset" do
   it "should support inner join with :semi_join_first option to do a semi join before the inner join" do
     @ds.join(@ds.as(:b), [:id]).select{[items[:id], b[:id].as(:b_id)]}.all.must_equal [{:id=>1, :b_id=>1}]
     @ds.join(@ds.as(:b), [:id], :semi_join_first=>true).select{[items[:id], b[:id].as(:b_id)]}.all.must_equal [{:id=>1, :b_id=>1}]
+    @ds.join(@ds.as(:b), [:id], :semi_join_first=>:temp_items_b).select{[items[:id], b[:id].as(:b_id)]}.all.must_equal [{:id=>1, :b_id=>1}]
+    @ds.join(@ds.as(:b), [:id], :semi_join_first=>:temp_items_b).select{[items[:id], b[:id].as(:b_id)]}.from_self.all.must_equal [{:id=>1, :b_id=>1}]
+    @db[:items].right_semi_join(@ds.join(@ds.as(:b), [:id], :semi_join_first=>:temp_items_b).select{[items[:id], b[:id].as(:b_id)]}.from_self(:alias=>:c), [:id]).all.must_equal [{:id=>1, :b_id=>1}]
+    proc{@ds.join(@ds.as(:b), [:id], :semi_join_first=>Object.new)}.must_raise Sequel::Error
   end
 
   it "should hoist nested CTEs" do

--- a/spec/impala_test.rb
+++ b/spec/impala_test.rb
@@ -79,6 +79,11 @@ describe "Impala dataset" do
     @ds.right_semi_join(@ds.as(:b), [:id]).all.must_equal [{:id=>1, :number=>10, :name=>'a'}]
   end
 
+  it "should support inner join with :semi_join_first option to do a semi join before the inner join" do
+    @ds.join(@ds.as(:b), [:id]).select{[items[:id], b[:id].as(:b_id)]}.all.must_equal [{:id=>1, :b_id=>1}]
+    @ds.join(@ds.as(:b), [:id], :semi_join_first=>true).select{[items[:id], b[:id].as(:b_id)]}.all.must_equal [{:id=>1, :b_id=>1}]
+  end
+
   it "should hoist nested CTEs" do
     DB[:i2].with(:i2, DB[:i1].with(:i1, DB[:items])).all.must_equal [{:id=>1, :number=>10, :name=>'a'}]
   end


### PR DESCRIPTION
This runs a LEFT SEMI JOIN between the two tables, which will remove
rows in the left hand side that are not matching in the right hand
side, use that as a subquery and then run an INNER JOIN on that subquery
and the original right hand side.

This will not work correctly if there are multiple tables being joined
and the join call using the :semi_join_first option uses an expression
with a qualified reference to a table that isn't the first table or
the table being joined to.  For example, the following will not work:

  DB[:a].join(:b, :a_id=>:id).
    join(:c, {:id=>Sequel[:b][:id]}, semi_join_first: true)

this is because the reference to b.id is not valid as b is in the
LEFT SEMI JOIN subquery in the left hand side, and that cannot be
referenced outside the subquery during the INNER JOIN.

That could theoretically be worked around by replacing all qualified
references in the join expression that do not match the first table
alias in the query or the table being joined with the the alias of
the subquery.